### PR TITLE
Add quotes for working directories containing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Typical usage:
 1. Create a container with the source mounted the image (which starts the build):
 
     ```
-    docker create -v $(pwd):/home/rust/src --name PROJECTNAME-build rust-crosscompile:latest
+    docker create -v "$(pwd)":/home/rust/src --name PROJECTNAME-build rust-crosscompile:latest
     ```
 
     If you'd like to use the included windows 10 theme create the container like this:
 
     ```
-    docker create -e WIN_THEME=true -v $(pwd):/home/rust/src --name PROJECTNAME-build rust-crosscompile:latest
+    docker create -e WIN_THEME=true -v "$(pwd)":/home/rust/src --name PROJECTNAME-build rust-crosscompile:latest
     ```
 
 2. Each time you want to build the project, start the Docker container.
@@ -36,7 +36,7 @@ If there are dependencies you need that are not included in the official image:
 3. Create a container with the source mounted the image (which kicks off the build):
 
     ```
-    docker create -v $(pwd):/home/rust/src --name PROJECTNAME-build PROJECTNAME-build-image
+    docker create -v "$(pwd)":/home/rust/src --name PROJECTNAME-build PROJECTNAME-build-image
     ```
 
 4. Each time you want to build the project, start the Docker container.


### PR DESCRIPTION
Yes, because spaces do exist

Without quoting (`""`), this happens
```
> tom@pc:~/My Folder/$ sudo docker create -v $(pwd):/home/rust/src --name reml-build rust-crosscompile:latest
invalid reference format: repository name must be lowercase
```